### PR TITLE
feat: improve accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,9 +47,15 @@
 
   <footer>
     <section class="footer__socials-container">
-      <img src="./images/facebook-f.svg" alt="" aria-hidden="true">
-      <img src="./images/twitter.svg" alt="" aria-hidden="true">
-      <img src="./images/instagram.svg" alt="" aria-hidden="true">
+      <a href="#" aria-label="Follow us on Facebook">
+        <img src="./images/facebook-f.svg" alt="" aria-hidden="true">
+      </a>
+      <a href="#" aria-label="Follow me on Twitter">
+        <img src="./images/twitter.svg" alt="" aria-hidden="true">
+      </a>
+      <a href="#" aria-label="Follow me on instagram">
+        <img src="./images/instagram.svg" alt="" aria-hidden="true">
+      </a>      
     </section>
     <section class="footer__copyright">
       &copy; Copyright Ping. All rights reserved.

--- a/styles.css
+++ b/styles.css
@@ -257,12 +257,16 @@ footer {
     justify-content: center;
     padding-bottom: 2em;
 }
-.footer__socials-container > img {
-    width: 40px;
-    height: 40px;
+.footer__socials-container a {
     border-radius: 50%;
     border: 1px solid var(--gray);
+    width: 41px;
+    height: 41px;
+}
+.footer__socials-container img {
     padding: 10px;
+    width: 40px;
+    height: 40px;
     filter: invert(38%) sepia(81%) saturate(1096%) hue-rotate(203deg) brightness(101%) contrast(91%);
 }
 


### PR DESCRIPTION
## What to be Improved:
- Social links will be skipped by screen readers.
- Because it will read those links as "Link, Main, or Landmark"
- That's it, No information of what the link is about or where it goes!

## Solution:
- There is an easy and straightforward way to **fix accessibility issues** with the help of some `aria` tags.
- `aria-label` will be used to add a label to the `<a>` tag, to tell the screen reader what to read.
- `aria-hidden` will be used to hide the `<img>` tag which contains the icon, since this doesn't serve any purpose to the screen reader user

## PS:
- Now the screen reader user will have a clear idea of the purpose of the link and where it goes. Much clearer!